### PR TITLE
Implement commit message suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,12 @@ require("copilot").setup {
 }
 ```
 
+### git commit messages
+
+When editing a commit message (`gitcommit` filetype), Copilot uses the staged
+diff (`git diff --staged`) to generate commit message suggestions. Enable
+`gitcommit` in the `filetypes` table to use this feature.
+
 ### logger
 
 Logs will be written to the `file` for anything of `file_log_level` or higher.

--- a/doc/copilot.txt
+++ b/doc/copilot.txt
@@ -299,6 +299,11 @@ won’t be used anymore. e.g.
     }
 <
 
+GIT COMMIT MESSAGES~
+
+When editing a commit message (`gitcommit` filetype), Copilot fetches the
+staged diff (`git diff --staged`) to provide commit message suggestions. Enable
+`gitcommit` in the |copilot-filetypes| table to use this feature.
 
 LOGGER ~
 

--- a/lua/copilot/util.lua
+++ b/lua/copilot/util.lua
@@ -74,6 +74,13 @@ function M.get_doc()
     position = params.position,
   }
 
+  if vim.bo.filetype == "gitcommit" then
+    local ok, diff = pcall(vim.fn.system, { "git", "diff", "--staged", "--no-color" })
+    if ok and diff and diff ~= "" then
+      doc.gitDiff = diff
+    end
+  end
+
   return doc
 end
 


### PR DESCRIPTION
## Summary
- add `gitDiff` to doc params for gitcommit buffers
- document commit message suggestions in README and help doc

## Testing
- `make test` *(fails: `nvim` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68856cb90730833095168cf9b6724866